### PR TITLE
Initial implementation of configurable EventBus

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -1,23 +1,32 @@
-import { IEventBus, IEvent, IEventHandler, ICommand } from './interfaces/index';
+import { IEventBus, IEvent, IEventHandler } from './interfaces/index';
 import { ObservableBus } from './utils/observable-bus';
 import { Metatype } from '@nestjs/common/interfaces';
 import { Component } from '@nestjs/common';
-import { EventObservable } from './interfaces/event-observable.interface';
 import { Observable } from 'rxjs/Observable';
 import { CommandBus } from './command-bus';
 import { InvalidSagaException } from './exceptions/invalid-saga.exception';
 import { EVENTS_HANDLER_METADATA } from './utils/constants';
 import { InvalidModuleRefException, Saga } from './index';
 import 'rxjs/add/operator/filter';
+import {IEventPublisher} from "./interfaces/events/event-publisher.interface";
+import {DefaultPubSub} from "./utils/default-pubsub";
 
 export type EventHandlerMetatype = Metatype<IEventHandler<IEvent>>;
 
 @Component()
 export class EventBus extends ObservableBus<IEvent> implements IEventBus {
     private moduleRef = null;
+    private _publisher: IEventPublisher;
 
     constructor(private readonly commandBus: CommandBus) {
         super();
+        this.useDefaultPublisher();
+    }
+
+    private useDefaultPublisher() {
+        const pubSub = new DefaultPubSub();
+        pubSub.bridgeEventsTo(this.subject$);
+        this._publisher = pubSub;
     }
 
     setModuleRef(moduleRef) {
@@ -25,7 +34,7 @@ export class EventBus extends ObservableBus<IEvent> implements IEventBus {
     }
 
     publish<T extends IEvent>(event: T) {
-        this.subject$.next(event);
+        this._publisher.publish(event);
     }
 
     ofType<T extends IEvent>(event: T & { name: string }) {
@@ -77,4 +86,13 @@ export class EventBus extends ObservableBus<IEvent> implements IEventBus {
     private reflectEventsNames(handler: EventHandlerMetatype): FunctionConstructor[] {
         return Reflect.getMetadata(EVENTS_HANDLER_METADATA, handler);
     }
+
+    get publisher(): IEventPublisher {
+        return this._publisher;
+    }
+
+    set publisher(thePublisher: IEventPublisher) {
+        this._publisher = thePublisher;
+    }
+
 }

--- a/src/interfaces/events/event-bus.interface.ts
+++ b/src/interfaces/events/event-bus.interface.ts
@@ -1,5 +1,7 @@
 import { IEvent } from './event.interface';
+import {EventHandlerMetatype} from "../../event-bus";
 
 export interface IEventBus {
     publish<T extends IEvent>(event: T);
+    register(handlers: EventHandlerMetatype[]);
 }

--- a/src/interfaces/events/event-publisher.interface.ts
+++ b/src/interfaces/events/event-publisher.interface.ts
@@ -1,0 +1,6 @@
+import {IEvent} from "./event.interface";
+import {Subject} from "rxjs/Subject";
+
+export interface IEventPublisher {
+    publish<T extends IEvent>(event: T);
+}

--- a/src/interfaces/events/message-source.interface.ts
+++ b/src/interfaces/events/message-source.interface.ts
@@ -1,0 +1,6 @@
+import {IEvent} from "./event.interface";
+import {Subject} from "rxjs/Subject";
+
+export interface IMessageSource {
+    bridgeEventsTo<T extends IEvent>(subject: Subject<T>);
+}

--- a/src/utils/default-pubsub.ts
+++ b/src/utils/default-pubsub.ts
@@ -1,0 +1,16 @@
+import {IEvent} from "../interfaces";
+import {Subject} from "rxjs/Subject";
+import {IEventPublisher} from "../interfaces/events/event-publisher.interface";
+import {IMessageSource} from "../interfaces/events/message-source.interface";
+
+export class DefaultPubSub implements IEventPublisher, IMessageSource {
+    private subject$: Subject<any>;
+
+    publish<T extends IEvent>(event: T) {
+        this.subject$.next(event);
+    }
+
+    bridgeEventsTo<T extends IEvent>(subject: Subject<T>) {
+        this.subject$ = subject;
+    }
+}


### PR DESCRIPTION
The event bus now delegates publishing to an implementation of IEventPublisher. By default,
it uses DefaultPubSub which is also an implementation of IMessageSource.
This default implementation immediately calls the "subject$.next(event)" on the configured "subject$".
This is usually the EventBus's subject$.

How to use with custom configuration (theoretically):

```
  onModuleInit() {
    this.command$.setModuleRef(this.moduleRef);
    this.event$.setModuleRef(this.moduleRef);

    const subscriber = new AMQPSubscriber(); <--- implements IMessageSource
    subscriber.bridgeEventsTo(this.event$); 
    const publisher = new AMQPPublisher(); <--- implements IEventPublisher
    this.event$.setPublisher(publisher);
    this.event$.register(EventHandlers);
    this.command$.register(CommandHandlers);
    this.event$.combineSagas([this.heroesGameSagas.dragonKilled]);
  }
```