### PR TITLE
Support promise for command handler, able to throw exception in handler.

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -21,15 +21,13 @@ export class CommandBus extends ObservableBus<ICommand> implements ICommandBus {
     this.moduleRef = moduleRef;
   }
 
-  execute<T extends ICommand>(command: T): Promise<any> {
+  execute<T extends ICommand>(command: T): any | Promise<any> {
     const handler = this.handlers.get(this.getCommandName(command));
     if (!handler) {
       throw new CommandHandlerNotFoundException();
     }
     this.subject$.next(command);
-    return new Promise(resolve => {
-      handler.execute(command, resolve);
-    });
+    return handler.execute(command);
   }
 
   bind<T extends ICommand>(handler: ICommandHandler<T>, name: string) {

--- a/src/interfaces/commands/command-bus.interface.ts
+++ b/src/interfaces/commands/command-bus.interface.ts
@@ -1,5 +1,5 @@
 import { ICommand } from './command.interface';
 
 export interface ICommandBus {
-  execute<T extends ICommand>(command: T): Promise<any>;
+  execute<T extends ICommand>(command: T): any | Promise<any>;
 }

--- a/src/interfaces/commands/command-handler.interface.ts
+++ b/src/interfaces/commands/command-handler.interface.ts
@@ -1,5 +1,5 @@
 import { ICommand } from './command.interface';
 
 export interface ICommandHandler<T extends ICommand> {
-  execute(command: T, resolve: (value?) => void);
+  execute(command: T): any | Promise<any>;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Changing of execute function in ICommandHandler interface, need update return data instead of resolve: (value?) => void

For example:
@CommandHandler(KillDragonCommand)
export class KillDragonHandler implements ICommandHandler<KillDragonCommand> {
    constructor(
        private readonly repository: HeroRepository,
        private readonly publisher: EventPublisher,
    ) { }

    async execute(command: KillDragonCommand) {
        console.log(clc.greenBright('KillDragonCommand...'));

        const { heroId, dragonId } = command;
        const hero = this.publisher.mergeObjectContext(
            await this.repository.findOneById(+heroId),
        );
        if (!hero) {
           // Able to throw exception.
            throw new BadRequestException('Bad request');
        }
        hero.killEnemy(dragonId);
        hero.commit();
       // Use return instead of resolve.
        return hero;
    }
}

## Other information