### PR TITLE
Fix unhandled promise rejection issue for command handler. Related to issue #24

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -27,8 +27,12 @@ export class CommandBus extends ObservableBus<ICommand> implements ICommandBus {
       throw new CommandHandlerNotFoundException();
     }
     this.subject$.next(command);
-    return new Promise(resolve => {
-      handler.execute(command, resolve);
+    return new Promise(async (resolve, reject) => {
+      try {
+        await handler.execute(command, resolve);
+      } catch (error) {
+        reject(error);
+      }
     });
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #24 


## What is the new behavior?
Will call promise reject from command bus if command handler occurred exception.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The caller may need to handle exception for command handler otherwise the application may result Internal server error.

for example:
```typescript
try {
  await this.commandBus.execute(new Command())
} (error) {
  // error handling
  handleError(error)
}
```
## Other information