### PR TITLE
feat: pass the commandName to CommandHandlerNotFoundException

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -18,9 +18,10 @@ export class CommandBus extends ObservableBus<ICommand> implements ICommandBus {
   }
 
   execute<T extends ICommand>(command: T): Promise<any> {
-    const handler = this.handlers.get(this.getCommandName(command));
+    const commandName = this.getCommandName(command);
+    const handler = this.handlers.get(commandName);
     if (!handler) {
-      throw new CommandHandlerNotFoundException();
+      throw new CommandHandlerNotFoundException(commandName);
     }
     this.subject$.next(command);
     return handler.execute(command);

--- a/src/exceptions/command-not-found.exception.ts
+++ b/src/exceptions/command-not-found.exception.ts
@@ -1,5 +1,6 @@
 export class CommandHandlerNotFoundException {
-  constructor(
-    public readonly message = 'CommandHandler not found exception!',
-  ) {}
+  public readonly message: string;
+  constructor(commandName: string) {
+    this.message = `CommandHandler of Command "${commandName}" not found exception!`;
+  }
 }


### PR DESCRIPTION
help identifying which Command triggered the CommandHandlerNotFoundException

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently, if the `CommandHandler` is not registered, only the following exception message is being raised `CommandHandler not found exception!`. It will help a bit to locate which Command actually triggered the exception.


## What is the new behavior?

Pass the `commandName` to the `CommandHandlerNotFoundException`

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information