### PR TITLE
Type infer the return type of `QueryBus.execute`

### DIFF
--- a/src/decorators/query-handler.decorator.ts
+++ b/src/decorators/query-handler.decorator.ts
@@ -1,8 +1,8 @@
 import 'reflect-metadata';
-import { IQuery } from '../interfaces';
+import { IQuery, IQueryResult } from '../interfaces';
 import { QUERY_HANDLER_METADATA } from './constants';
 
-export const QueryHandler = (query: IQuery): ClassDecorator => {
+export const QueryHandler = <TResult extends IQueryResult = any>(query: IQuery<TResult>): ClassDecorator => {
   return (target: object) => {
     Reflect.defineMetadata(QUERY_HANDLER_METADATA, query, target);
   };

--- a/src/interfaces/queries/query-bus.interface.ts
+++ b/src/interfaces/queries/query-bus.interface.ts
@@ -1,5 +1,6 @@
 import { IQuery } from './query.interface';
+import { IQueryResult } from './query-result.interface';
 
 export interface IQueryBus {
-  execute<T extends IQuery, TRes>(query: T): Promise<TRes>;
+  execute<TResult extends IQueryResult, T extends IQuery<TResult>>(query: T): Promise<TResult>;
 }

--- a/src/interfaces/queries/query-handler.interface.ts
+++ b/src/interfaces/queries/query-handler.interface.ts
@@ -1,5 +1,6 @@
 import { IQuery } from './query.interface';
+import { IQueryResult } from './query-result.interface';
 
-export interface IQueryHandler<T extends IQuery = any, TRes = any> {
-  execute(query: T): Promise<TRes>;
+export interface IQueryHandler<TResult extends IQueryResult = any, T extends IQuery<TResult> = any> {
+  execute(query: T): Promise<TResult>;
 }

--- a/src/interfaces/queries/query.interface.ts
+++ b/src/interfaces/queries/query.interface.ts
@@ -1,1 +1,3 @@
-export interface IQuery {}
+import { IQueryResult } from './query-result.interface';
+
+export interface IQuery<TResult extends IQueryResult> {}

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -7,17 +7,17 @@ import { InvalidQueryHandlerException } from './exceptions/invalid-query-handler
 import { IQuery, IQueryBus, IQueryHandler, IQueryResult } from './interfaces';
 import { ObservableBus } from './utils/observable-bus';
 
-export type QueryHandlerType = Type<IQueryHandler<IQuery, IQueryResult>>;
+export type QueryHandlerType = Type<IQueryHandler<IQuery<any>>>;
 
 @Injectable()
-export class QueryBus extends ObservableBus<IQuery> implements IQueryBus {
-  private handlers = new Map<string, IQueryHandler<IQuery, IQueryResult>>();
+export class QueryBus extends ObservableBus<IQuery<any>> implements IQueryBus {
+  private handlers = new Map<string, IQueryHandler<IQuery<any>>>();
 
   constructor(private readonly moduleRef: ModuleRef) {
     super();
   }
 
-  async execute<T extends IQuery, TResult extends IQueryResult>(
+  async execute<TResult extends IQueryResult, T extends IQuery<TResult>>(
     query: T,
   ): Promise<TResult> {
     const handler = this.handlers.get(this.getQueryName(query));
@@ -28,7 +28,7 @@ export class QueryBus extends ObservableBus<IQuery> implements IQueryBus {
     return result as TResult;
   }
 
-  bind<T extends IQuery, TResult>(
+  bind<TResult extends IQueryResult, T extends IQuery<TResult>>(
     handler: IQueryHandler<T, TResult>,
     name: string,
   ) {
@@ -48,7 +48,7 @@ export class QueryBus extends ObservableBus<IQuery> implements IQueryBus {
     if (!target) {
       throw new InvalidQueryHandlerException();
     }
-    this.bind(instance as IQueryHandler<IQuery, IQueryResult>, target.name);
+    this.bind(instance as IQueryHandler<IQuery<any>>, target.name);
   }
 
   private getQueryName(query): string {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

The return type of `QueryBus.execute` can not be inferred.

```typescript
export class ExampleQuery implements IQuery {}

@QueryHandler(ExampleQuery)
export class ExampleQueryHandler implements IQueryHandler<ExampleQuery> {
  execute(query: ExampleQuery) {
    return ['some_string'];
  }
}


const result = commandBus.execute(new ExampleQuery());
// type of `result` is `any`
```

Issue Number: #167 


## What is the new behavior?

The return type of `QueryBus.execute` is inferred from the executed query.

```typescript
export class ExampleQuery implements IQuery<string[]> {}

@QueryHandler(ExampleQuery)
export class ExampleQueryHandler implements IQueryHandler<ExampleQuery> {
  execute(query: ExampleQuery) {
    return ['some_string'];
  }
}

const result = commandBus.execute(new ExampleQuery());
// type of `result` is `string[]`
```


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I could not find where the set a multi-line commit message to meet the requirements.
Should my branch have a single commit?