### PR TITLE
fix: Change AggregateRoot's commit() to use publishAll()

### DIFF
--- a/src/aggregate-root.ts
+++ b/src/aggregate-root.ts
@@ -19,8 +19,10 @@ export abstract class AggregateRoot<EventBase extends IEvent = IEvent> {
 
   publish<T extends EventBase = EventBase>(event: T) {}
 
+  publishAll<T extends EventBase = EventBase>(event: T[]) {}
+
   commit() {
-    this[INTERNAL_EVENTS].forEach((event) => this.publish(event));
+    this.publishAll(this[INTERNAL_EVENTS]);
     this[INTERNAL_EVENTS].length = 0;
   }
 

--- a/src/event-publisher.ts
+++ b/src/event-publisher.ts
@@ -16,6 +16,10 @@ export class EventPublisher<EventBase extends IEvent = IEvent> {
   ): T {
     const eventBus = this.eventBus;
     return class extends metatype {
+      publish(event: EventBase) {
+        eventBus.publish(event);
+      }
+
       publishAll(events: EventBase[]) {
         eventBus.publishAll(events);
       }
@@ -24,6 +28,10 @@ export class EventPublisher<EventBase extends IEvent = IEvent> {
 
   mergeObjectContext<T extends AggregateRoot<EventBase>>(object: T): T {
     const eventBus = this.eventBus;
+    object.publish = (event: EventBase) => {
+      eventBus.publish(event);
+    };
+
     object.publishAll = (events: EventBase[]) => {
       eventBus.publishAll(events);
     };

--- a/src/event-publisher.ts
+++ b/src/event-publisher.ts
@@ -16,16 +16,16 @@ export class EventPublisher<EventBase extends IEvent = IEvent> {
   ): T {
     const eventBus = this.eventBus;
     return class extends metatype {
-      publish(event: EventBase) {
-        eventBus.publish(event);
+      publishAll(events: EventBase[]) {
+        eventBus.publishAll(events);
       }
     };
   }
 
   mergeObjectContext<T extends AggregateRoot<EventBase>>(object: T): T {
     const eventBus = this.eventBus;
-    object.publish = (event: EventBase) => {
-      eventBus.publish(event);
+    object.publishAll = (events: EventBase[]) => {
+      eventBus.publishAll(events);
     };
     return object;
   }


### PR DESCRIPTION
Using publishAll() instead of publish() enables implementations of IEventBus to
support correct transactional semantics when used together with EventPublisher.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`AggregateRoot`'s current `commit()` implementation invokes `publish()` instead of a `publishAll()`, This prevents `IEventPublisher.publishAll()` from ever being called which breaks transactional semantics when publishing events to an `IEventPublisher` implementation. 

Issue Number: #325

## What is the new behavior?

A new `publishAll()` method has been introduced to `AggregateRoot` and `EventPublisher` has been updated to use the corresponding API of `IEventBus`. This allows the user to implement the already existing `IEventPublisher.publishAll()` method to support atomic/transactional event publishing. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
I don't believe this introduces any breaking changes due to the following two observations:
* The default implementation of `AggregateRoot.publish()` and the new `AggregateRoot.publishAll()` both do nothing.
* The overridden implementation of the new `AggregateRoot.publishAll()`, when used together with `EventPublisher`, will invoke `EventBus.publishAll()`. The current implementation of `EventBus.publishAll()` assumes the original behavior (that is, invoking `IEventPublisher.publish()` for each event) unless the user has explicitly implemented `IEventPublisher.publishAll()` (likely with intent to support an atomic commit).


## Other information

none