### PR TITLE
fix(): change aggregate root geteventhandler method access modifier

### DIFF
--- a/src/aggregate-root.ts
+++ b/src/aggregate-root.ts
@@ -46,7 +46,7 @@ export abstract class AggregateRoot<EventBase extends IEvent = IEvent> {
     handler && handler.call(this, event);
   }
 
-  private getEventHandler<T extends EventBase = EventBase>(
+  protected getEventHandler<T extends EventBase = EventBase>(
     event: T,
   ): Function | undefined {
     const handler = `on${this.getEventName(event)}`;


### PR DESCRIPTION
Changes AggregateRoot's getEventHandler method access modifier from private to protected.
It will allow overwriting getEventHandler method in subclasses.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It is not possible to overwrite AggregateRoot's getEventHandler method in subclass.

Issue Number: N/A


## What is the new behavior?
It is possible to overwrite AggregateRoot's getEventHandler method in subclass.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information