### PR TITLE
fix(): add return type for command bus execute method promise

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -35,7 +35,7 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
     this._publisher = _publisher;
   }
 
-  execute<T extends CommandBase>(command: T): Promise<any> {
+  execute<T extends CommandBase, R = any>(command: T): Promise<R> {
     const commandName = this.getCommandName(command as any);
     const handler = this.handlers.get(commandName);
     if (!handler) {

--- a/src/interfaces/commands/command-bus.interface.ts
+++ b/src/interfaces/commands/command-bus.interface.ts
@@ -1,5 +1,5 @@
 import { ICommand } from './command.interface';
 
 export interface ICommandBus<CommandBase extends ICommand = ICommand> {
-  execute<T extends CommandBase>(command: T): Promise<any>;
+  execute<T extends CommandBase, R = any>(command: T): Promise<R>;
 }


### PR DESCRIPTION
Changes ICommandBus and CommandBus execute method return type.
This allows to precisely specify the return value form CommandBus execute method.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We can not specify return type from CommandBus execute method.
 
Issue Number: N/A


## What is the new behavior?
We can specify return type from CommandBus execute method.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information