### PR TITLE
fix(): Bind "this" keyword in saga scope

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -77,7 +77,7 @@ export class EventBus<EventBase extends IEvent = IEvent>
         if (!instance) {
           throw new InvalidSagaException();
         }
-        return metadata.map((key: string) => instance[key]);
+        return metadata.map((key: string) => instance[key].bind(instance));
       })
       .reduce((a, b) => a.concat(b), []);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
"this" keyword was undefined in saga scope. This change will allow saga scope to access "this" correctly.
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
"this" is undefined in saga scope.


## What is the new behavior?
This change will allow saga scope to access "this" correctly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```