### PR TITLE
feat(saga): allow method style saga

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -77,7 +77,7 @@ export class EventBus<EventBase extends IEvent = IEvent>
         if (!instance) {
           throw new InvalidSagaException();
         }
-        return metadata.map((key: string) => instance[key]);
+        return metadata.map((key: string) => instance[key].bind(instance));
       })
       .reduce((a, b) => a.concat(b), []);
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
> Where should I add the required tests ?
- [ ] Docs have been added / updated (for bug fixes / features)
> Should I update the documentation to show usage with a method ?


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `this` reference is lost when using a non-arrow function as saga.

## What is the new behavior?
The instance context is bound to the method within the event bus, upon registration.
We can now use decorated methods and keep access to the context

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
In RxJs7, async iterators will be supported. As I am using it in my project, I wanted for the most simple sagas, to abstract the rxjs logic away.

```ts
class DomainSaga {

    @ReactTo(EventA, EventB)
    async *somethingHappened(event: EventA | EventB){
          this.logger.log(event)
          yield new CommandA()

          for(const item of event){
              yield new CommandB(item.id)
          }
    }
}
```
Because async generator can't be arrow functions, the fact that the event bus was removing the context reference was preventing my saga to use external dependencies

That's why this PR :) 