### PR TITLE
fix(): don't resolve handlers based on names

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@commitlint/config-angular": "13.2.0",
     "@nestjs/common": "8.1.1",
     "@nestjs/core": "8.1.1",
-    "@types/node": "16.0.1",
     "@types/jest": "27.0.2",
+    "@types/node": "16.0.1",
     "@typescript-eslint/eslint-plugin": "5.1.0",
     "@typescript-eslint/parser": "5.1.0",
     "eslint": "8.0.1",
@@ -36,13 +36,15 @@
     "release-it": "14.11.6",
     "rxjs": "7.4.0",
     "ts-jest": "27.0.7",
-    "typescript": "4.4.4"
+    "typescript": "4.4.4",
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^8.0.0",
     "@nestjs/core": "^8.0.0",
     "reflect-metadata": "0.1.13",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "uuid": "^8.3.2"
   },
   "lint-staged": {
     "*.ts": [

--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -1,7 +1,7 @@
 import { Injectable, Type } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import 'reflect-metadata';
-import { COMMAND_HANDLER_METADATA } from './decorators/constants';
+import { COMMAND_HANDLER_METADATA, COMMAND_METADATA } from './decorators/constants';
 import { CommandHandlerNotFoundException } from './exceptions/command-not-found.exception';
 import { DefaultCommandPubSub } from './helpers/default-command-pubsub';
 import { InvalidCommandHandlerException } from './index';
@@ -12,6 +12,7 @@ import {
   ICommandPublisher,
 } from './interfaces/index';
 import { ObservableBus } from './utils/observable-bus';
+import { CommandMetadata } from './interfaces/commands/command-metadata.interface';
 
 export type CommandHandlerType = Type<ICommandHandler<ICommand>>;
 
@@ -36,17 +37,17 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
   }
 
   execute<T extends CommandBase, R = any>(command: T): Promise<R> {
-    const commandName = this.getCommandName(command as any);
-    const handler = this.handlers.get(commandName);
+    const commandId = this.getCommandId(command);
+    const handler = this.handlers.get(commandId);
     if (!handler) {
-      throw new CommandHandlerNotFoundException(commandName);
+      throw new CommandHandlerNotFoundException(commandId);
     }
     this.subject$.next(command);
     return handler.execute(command);
   }
 
-  bind<T extends CommandBase>(handler: ICommandHandler<T>, name: string) {
-    this.handlers.set(name, handler);
+  bind<T extends CommandBase>(handler: ICommandHandler<T>, id: string) {
+    this.handlers.set(id, handler);
   }
 
   register(handlers: CommandHandlerType[] = []) {
@@ -58,20 +59,36 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
     if (!instance) {
       return;
     }
-    const target = this.reflectCommandName(handler);
+    const target = this.reflectCommandId(handler);
     if (!target) {
       throw new InvalidCommandHandlerException();
     }
-    this.bind(instance as ICommandHandler<CommandBase>, target.name);
+    this.bind(instance as ICommandHandler<CommandBase>, target);
   }
 
-  private getCommandName(command: Function): string {
-    const { constructor } = Object.getPrototypeOf(command);
-    return constructor.name as string;
+  private getCommandId(command: CommandBase): string {
+    const { constructor: commandType } = Object.getPrototypeOf(command);
+    const commandMetadata: CommandMetadata = Reflect.getMetadata(
+      COMMAND_METADATA,
+      commandType,
+    );
+    if (!commandMetadata) {
+      throw new CommandHandlerNotFoundException(commandType.name);
+    }
+
+    return commandMetadata.id;
   }
 
-  private reflectCommandName(handler: CommandHandlerType): FunctionConstructor {
-    return Reflect.getMetadata(COMMAND_HANDLER_METADATA, handler);
+  private reflectCommandId(handler: CommandHandlerType): string | undefined {
+    const command: Type<ICommand> = Reflect.getMetadata(
+      COMMAND_HANDLER_METADATA,
+      handler,
+    );
+    const commandMetadata: CommandMetadata = Reflect.getMetadata(
+      COMMAND_METADATA,
+      command,
+    );
+    return commandMetadata.id;
   }
 
   private useDefaultPublisher() {

--- a/src/decorators/command-handler.decorator.ts
+++ b/src/decorators/command-handler.decorator.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { ICommand } from '../index';
-import { COMMAND_HANDLER_METADATA } from './constants';
+import { COMMAND_HANDLER_METADATA, COMMAND_METADATA } from './constants';
+import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest command handler. A command handler
@@ -14,6 +15,9 @@ import { COMMAND_HANDLER_METADATA } from './constants';
  */
 export const CommandHandler = (command: ICommand): ClassDecorator => {
   return (target: object) => {
+    if (!Reflect.hasMetadata(COMMAND_METADATA, command)) {
+      Reflect.defineMetadata(COMMAND_METADATA, { id: v4() }, command);
+    }
     Reflect.defineMetadata(COMMAND_HANDLER_METADATA, command, target);
   };
 };

--- a/src/decorators/constants.ts
+++ b/src/decorators/constants.ts
@@ -1,4 +1,6 @@
+export const COMMAND_METADATA = '__command__';
 export const COMMAND_HANDLER_METADATA = '__commandHandler__';
+export const QUERY_METADATA = '__query__';
 export const QUERY_HANDLER_METADATA = '__queryHandler__';
 export const EVENTS_HANDLER_METADATA = '__eventsHandler';
 export const SAGA_METADATA = '__saga__';

--- a/src/decorators/query-handler.decorator.ts
+++ b/src/decorators/query-handler.decorator.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { IQuery } from '../interfaces';
-import { QUERY_HANDLER_METADATA } from './constants';
+import { QUERY_HANDLER_METADATA, QUERY_METADATA } from './constants';
+import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest query handler. A query handler
@@ -14,6 +15,9 @@ import { QUERY_HANDLER_METADATA } from './constants';
  */
 export const QueryHandler = (query: IQuery): ClassDecorator => {
   return (target: object) => {
+    if (!Reflect.hasMetadata(QUERY_METADATA, query)) {
+      Reflect.defineMetadata(QUERY_METADATA, { id: v4() }, query);
+    }
     Reflect.defineMetadata(QUERY_HANDLER_METADATA, query, target);
   };
 };

--- a/src/interfaces/commands/command-metadata.interface.ts
+++ b/src/interfaces/commands/command-metadata.interface.ts
@@ -1,0 +1,3 @@
+export interface CommandMetadata {
+  id: string;
+}

--- a/src/interfaces/queries/query-metadata.interface.ts
+++ b/src/interfaces/queries/query-metadata.interface.ts
@@ -1,0 +1,3 @@
+export interface QueryMetadata {
+  id: string;
+}

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -1,7 +1,7 @@
 import { Injectable, Type } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import 'reflect-metadata';
-import { QUERY_HANDLER_METADATA } from './decorators/constants';
+import { QUERY_HANDLER_METADATA, QUERY_METADATA } from './decorators/constants';
 import { QueryHandlerNotFoundException } from './exceptions';
 import { InvalidQueryHandlerException } from './exceptions/invalid-query-handler.exception';
 import { DefaultQueryPubSub } from './helpers/default-query-pubsub';
@@ -13,11 +13,10 @@ import {
   IQueryResult,
 } from './interfaces';
 import { ObservableBus } from './utils/observable-bus';
+import { QueryMetadata } from './interfaces/queries/query-metadata.interface';
 
-export type QueryHandlerType<
-  QueryBase extends IQuery = IQuery,
-  QueryResultBase extends IQueryResult = IQueryResult
-> = Type<IQueryHandler<QueryBase, QueryResultBase>>;
+export type QueryHandlerType<QueryBase extends IQuery = IQuery,
+  QueryResultBase extends IQueryResult = IQueryResult> = Type<IQueryHandler<QueryBase, QueryResultBase>>;
 
 @Injectable()
 export class QueryBus<QueryBase extends IQuery = IQuery>
@@ -42,10 +41,10 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
   async execute<T extends QueryBase, TResult = any>(
     query: T,
   ): Promise<TResult> {
-    const queryName = this.getQueryName((query as any) as Function);
-    const handler = this.handlers.get(queryName);
+    const queryId = this.getQueryId(query);
+    const handler = this.handlers.get(queryId);
     if (!handler) {
-      throw new QueryHandlerNotFoundException(queryName);
+      throw new QueryHandlerNotFoundException(queryId);
     }
 
     this.subject$.next(query);
@@ -55,9 +54,9 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
 
   bind<T extends QueryBase, TResult = any>(
     handler: IQueryHandler<T, TResult>,
-    name: string,
+    queryId: string,
   ) {
-    this.handlers.set(name, handler);
+    this.handlers.set(queryId, handler);
   }
 
   register(handlers: QueryHandlerType<QueryBase>[] = []) {
@@ -69,22 +68,38 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
     if (!instance) {
       return;
     }
-    const target = this.reflectQueryName(handler);
+    const target = this.reflectQueryId(handler);
     if (!target) {
       throw new InvalidQueryHandlerException();
     }
-    this.bind(instance as IQueryHandler<QueryBase, IQueryResult>, target.name);
+    this.bind(instance as IQueryHandler<QueryBase, IQueryResult>, target);
   }
 
-  private getQueryName(query: Function): string {
-    const { constructor } = Object.getPrototypeOf(query);
-    return constructor.name as string;
+  private getQueryId(query: QueryBase): string {
+    const { constructor: queryType } = Object.getPrototypeOf(query);
+    const queryMetadata: QueryMetadata = Reflect.getMetadata(
+      QUERY_METADATA,
+      queryType,
+    );
+    if (!queryMetadata) {
+      throw new QueryHandlerNotFoundException(queryType.name);
+    }
+
+    return queryMetadata.id;
   }
 
-  private reflectQueryName(
+  private reflectQueryId(
     handler: QueryHandlerType<QueryBase>,
-  ): FunctionConstructor {
-    return Reflect.getMetadata(QUERY_HANDLER_METADATA, handler);
+  ): string | undefined {
+    const query: Type<QueryBase> = Reflect.getMetadata(
+      QUERY_HANDLER_METADATA,
+      handler,
+    );
+    const queryMetadata: QueryMetadata = Reflect.getMetadata(
+      QUERY_METADATA,
+      query,
+    );
+    return queryMetadata.id;
   }
 
   private useDefaultPublisher() {


### PR DESCRIPTION
Previously, the handler for command/query (action) was assigned by the
action name. When there were multiple actions with the same name
handlers were overwritten.
Use ids to differentiate actions with the same name.

Closes @nestjs/cqrs#787

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #787


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information