### PR TITLE
refactor(): fix not working eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,8 +8,7 @@ module.exports = {
   extends: [
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
-    'prettier',
-    'prettier/@typescript-eslint',
+    'prettier'
   ],
   root: true,
   env: {

--- a/src/aggregate-root.ts
+++ b/src/aggregate-root.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { IEvent } from './interfaces';
+import { IEvent, IEventHandler } from './interfaces';
+import { Type } from '@nestjs/common';
 
 const INTERNAL_EVENTS = Symbol();
 const IS_AUTO_COMMIT_ENABLED = Symbol();
@@ -50,7 +51,7 @@ export abstract class AggregateRoot<EventBase extends IEvent = IEvent> {
 
   protected getEventHandler<T extends EventBase = EventBase>(
     event: T,
-  ): Function | undefined {
+  ): Type<IEventHandler> | undefined {
     const handler = `on${this.getEventName(event)}`;
     return this[handler];
   }

--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -65,7 +65,7 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
     this.bind(instance as ICommandHandler<CommandBase>, target.name);
   }
 
-  private getCommandName(command: Function): string {
+  private getCommandName(command: Type<CommandBase>): string {
     const { constructor } = Object.getPrototypeOf(command);
     return constructor.name as string;
   }

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -42,7 +42,7 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
   async execute<T extends QueryBase, TResult = any>(
     query: T,
   ): Promise<TResult> {
-    const queryName = this.getQueryName((query as any) as Function);
+    const queryName = this.getQueryName((query as any) as Type<QueryBase>);
     const handler = this.handlers.get(queryName);
     if (!handler) {
       throw new QueryHandlerNotFoundException(queryName);
@@ -76,7 +76,7 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
     this.bind(instance as IQueryHandler<QueryBase, IQueryResult>, target.name);
   }
 
-  private getQueryName(query: Function): string {
+  private getQueryName(query: Type<QueryBase>): string {
     const { constructor } = Object.getPrototypeOf(query);
     return constructor.name as string;
   }


### PR DESCRIPTION
prettier/@typescript-eslint is now a part
of the prettier rules.
Removed errors produced the Function type.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`npm run lint` returns
```
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
```

Issue Number: N/A


## What is the new behavior?
lint passes


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information