### PR TITLE
fix: type inference of type

### DIFF
--- a/src/operators/of-type.spec.ts
+++ b/src/operators/of-type.spec.ts
@@ -3,10 +3,17 @@ import { ofType } from './of-type';
 import { IEvent } from '../interfaces';
 
 describe('operators/ofType', () => {
-  class A implements IEvent {}
-  class B implements IEvent {}
+  class A implements IEvent {
+    keyAOrB: string = 'keyAOrB';
+    keyAOnly: string = 'keyAOnly';
+  }
+  class B implements IEvent {
+    keyAOrB: string = 'keyAOrB';
+  }
   class SubA extends A {}
-  class C implements IEvent {}
+  class C implements IEvent {
+    keyCOptional?: string;
+  }
 
   let stream: Subject<any>;
   let output: IEvent[];
@@ -32,7 +39,7 @@ describe('operators/ofType', () => {
     expectedResults.push(new A());
 
     stream.next(new B());
-    stream.next(...expectedResults);
+    expectedResults.forEach((event) => stream.next(event));
     stream.next(new Date());
 
     expect(output).toEqual(expectedResults);
@@ -45,5 +52,36 @@ describe('operators/ofType', () => {
     expectedResults.forEach((event) => stream.next(event));
 
     expect(output).toEqual(expectedResults);
+  });
+
+  // TypeScript TSC test, if this compiles it passes
+  it('should infer return types of similar unions unions', (done) => {
+    stream.pipe(ofType(A, B)).subscribe((event) => {
+      event.keyAOrB;
+      // @ts-expect-error -- A | B cannot reference a B only key
+      event.keyBOnly;
+      done();
+    });
+
+    stream.next(new A());
+  });
+
+  // TypeScript TSC test, if this compiles it passes
+  it('should infer return types of disparate unions', (done) => {
+    stream.pipe(ofType(A, C)).subscribe((event) => {
+      // @ts-expect-error -- A | C cannot reference a key that is not on C
+      event.keyAOnly;
+
+      if (event instanceof A) {
+        event.keyAOnly;
+      }
+
+      if (event instanceof C) {
+        event.keyCOptional;
+      }
+      done();
+    });
+
+    stream.next(new A());
   });
 });

--- a/src/operators/of-type.ts
+++ b/src/operators/of-type.ts
@@ -11,11 +11,13 @@ import { IEvent } from '../interfaces';
  *
  * @return A stream only emitting the filtered instances.
  */
-export function ofType<TInput extends IEvent, TOutput extends IEvent>(
-  ...types: Type<TOutput>[]
+export function ofType<TInput extends IEvent, T extends Type<IEvent>[]>(
+  ...types: T
 ) {
-  const isInstanceOf = (event: IEvent): event is TOutput =>
+  type InstanceOf<T> = T extends Type<infer I> ? I : never;
+  const isInstanceOf = (event: IEvent): event is InstanceOf<T[number]> =>
     !!types.find((classType) => event instanceof classType);
-  return (source: Observable<TInput>): Observable<TOutput> =>
+
+  return (source: Observable<TInput>): Observable<InstanceOf<T[number]>> =>
     source.pipe(filter(isInstanceOf));
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using `ofType` with more than one type it would try to collapse those down into a single type, ie `A | B` would become A if B was essentially the same as A but with a few extra properties. And if the types couldn't be collapsed because they were incompatible then you would just get an error requiring the generics to be manually filled int

Issue Number: N/A


## What is the new behavior?
The `ofType()` can now property infer types of unions wether they are similar or disparate

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
Technically the generics of `ofType()` are changing so that the second parameter is an array rather than a union.
I think this is relatively low risk as most people would be inferring the type and if someone is providing the generic it is probably because it couldn't be inferred which this should fix

## Other information
