### PR TITLE
fix(event-bus): distinguish between events

### DIFF
--- a/src/decorators/constants.ts
+++ b/src/decorators/constants.ts
@@ -2,5 +2,6 @@ export const COMMAND_METADATA = '__command__';
 export const COMMAND_HANDLER_METADATA = '__commandHandler__';
 export const QUERY_METADATA = '__query__';
 export const QUERY_HANDLER_METADATA = '__queryHandler__';
+export const EVENT_METADATA = '__event__';
 export const EVENTS_HANDLER_METADATA = '__eventsHandler__';
 export const SAGA_METADATA = '__saga__';

--- a/src/decorators/events-handler.decorator.ts
+++ b/src/decorators/events-handler.decorator.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { IEvent } from '../index';
-import { EVENTS_HANDLER_METADATA } from './constants';
+import { EVENT_METADATA, EVENTS_HANDLER_METADATA } from './constants';
+import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest event handler. An event handler
@@ -14,6 +15,12 @@ import { EVENTS_HANDLER_METADATA } from './constants';
  */
 export const EventsHandler = (...events: IEvent[]): ClassDecorator => {
   return (target: object) => {
+    events.forEach((event) => {
+      if (!Reflect.hasMetadata(EVENT_METADATA, event)) {
+        Reflect.defineMetadata(EVENT_METADATA, { id: v4() }, event);
+      }
+    });
+    
     Reflect.defineMetadata(EVENTS_HANDLER_METADATA, events, target);
   };
 };

--- a/src/helpers/default-get-event-id.ts
+++ b/src/helpers/default-get-event-id.ts
@@ -1,0 +1,18 @@
+import { IEvent } from '../interfaces';
+import { EVENT_METADATA } from '../decorators/constants';
+import { Type } from '@nestjs/common';
+
+export const defaultGetEventId = <EventBase extends IEvent = IEvent>(
+  event: EventBase,
+): string => {
+  const { constructor } = Object.getPrototypeOf(event);
+  return Reflect.getMetadata(EVENT_METADATA, constructor).id;
+};
+
+export const defaultReflectEventId = <
+  EventBase extends Type<IEvent> = Type<IEvent>,
+>(
+  event: EventBase,
+): string => {
+  return Reflect.getMetadata(EVENT_METADATA, event).id;
+};

--- a/src/helpers/default-get-event-name.ts
+++ b/src/helpers/default-get-event-name.ts
@@ -1,8 +1,0 @@
-import { IEvent } from '../interfaces';
-
-export const defaultGetEventName = <EventBase extends IEvent = IEvent>(
-  event: EventBase,
-): string => {
-  const { constructor } = Object.getPrototypeOf(event);
-  return constructor.name as string;
-};


### PR DESCRIPTION
Add id to every event class to make it possible
to distinguish between events with the same name.

Closes #790

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When we have two events with the same name and each of them has its own handlers then when any of them is published all of those handlers will be executed.

Issue Number: #790


## What is the new behavior?
Only handlers registered for the specific class are executed.

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No
- [x] It's not changing the API but I hope nobody relies on that bug

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
