### PR TITLE
fix(event-bus): support events extending a base class

### DIFF
--- a/src/decorators/events-handler.decorator.ts
+++ b/src/decorators/events-handler.decorator.ts
@@ -16,7 +16,7 @@ import { v4 } from 'uuid';
 export const EventsHandler = (...events: IEvent[]): ClassDecorator => {
   return (target: object) => {
     events.forEach((event) => {
-      if (!Reflect.hasMetadata(EVENT_METADATA, event)) {
+      if (!Reflect.hasOwnMetadata(EVENT_METADATA, event)) {
         Reflect.defineMetadata(EVENT_METADATA, { id: v4() }, event);
       }
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

The handler for an event inheriting a base event will be called twice, once for the child class, another time for the base class

```ts
abstract class AbstractEvent {}

class ConcreteEvent extends AbstractEvent {}

@EventsHandler(ConcreteEvent)
export class ConcreteEventHandler implements IEventHandler<ConcreteEvent> {
  constructor(private readonly repository: InvoiceEventPrismaCommandRepository) {}

  async handle(args: AbstractEvent) {
    // this is called twice
  }
}
```

Issue Number: N/A

## What is the new behavior?

The handler is only called once

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
