### PR TITLE
fix: command handler decorator argument type

### DIFF
--- a/src/decorators/command-handler.decorator.ts
+++ b/src/decorators/command-handler.decorator.ts
@@ -13,7 +13,9 @@ import { v4 } from 'uuid';
  *
  * @see https://docs.nestjs.com/recipes/cqrs#commands
  */
-export const CommandHandler = (command: ICommand): ClassDecorator => {
+export const CommandHandler = (
+  command: new (...args: unknown[]) => ICommand,
+): ClassDecorator => {
   return (target: object) => {
     if (!Reflect.hasMetadata(COMMAND_METADATA, command)) {
       Reflect.defineMetadata(COMMAND_METADATA, { id: v4() }, command);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `CommandHandler` class decorator is supposed to be provided a constructor of `ICommand`, but its signature expects an instance of `ICommand`

Issue Number: N/A


## What is the new behavior?

The `CommandHandler` class decorator now expects a constructor of `ICommand`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
