### PR TITLE
[Feature] query result inference

### DIFF
--- a/src/interfaces/queries/query-bus.interface.ts
+++ b/src/interfaces/queries/query-bus.interface.ts
@@ -1,5 +1,8 @@
+import { IQueryResult } from './query-result.interface';
 import { IQuery } from './query.interface';
 
 export interface IQueryBus<QueryBase extends IQuery = IQuery> {
-  execute<T extends QueryBase = QueryBase, TRes = any>(query: T): Promise<TRes>;
+  execute<T extends QueryBase = QueryBase, TRes = IQueryResult<QueryBase>>(
+    query: T,
+  ): Promise<TRes>;
 }

--- a/src/interfaces/queries/query-handler.interface.ts
+++ b/src/interfaces/queries/query-handler.interface.ts
@@ -1,5 +1,6 @@
+import { IQueryResult } from './query-result.interface';
 import { IQuery } from './query.interface';
 
-export interface IQueryHandler<T extends IQuery = any, TRes = any> {
+export interface IQueryHandler<T extends IQuery = any, TRes = IQueryResult<T>> {
   execute(query: T): Promise<TRes>;
 }

--- a/src/interfaces/queries/query-result.interface.ts
+++ b/src/interfaces/queries/query-result.interface.ts
@@ -1,1 +1,6 @@
-export interface IQueryResult {}
+import { IQuery } from './query.interface';
+
+export type IQueryResult<
+  T extends IQuery = any,
+  TDefault = any,
+> = T extends IQuery<infer R> ? R : TDefault;

--- a/src/interfaces/queries/query.interface.ts
+++ b/src/interfaces/queries/query.interface.ts
@@ -1,1 +1,2 @@
-export interface IQuery {}
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export interface IQuery<TRes = any> {}

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -10,18 +10,21 @@ import {
   IQueryBus,
   IQueryHandler,
   IQueryPublisher,
-  IQueryResult
+  IQueryResult,
 } from './interfaces';
 import { QueryMetadata } from './interfaces/queries/query-metadata.interface';
 import { ObservableBus } from './utils/observable-bus';
 
-export type QueryHandlerType<QueryBase extends IQuery = IQuery,
-  QueryResultBase extends IQueryResult = IQueryResult> = Type<IQueryHandler<QueryBase, QueryResultBase>>;
+export type QueryHandlerType<
+  QueryBase extends IQuery = IQuery,
+  QueryResultBase extends IQueryResult<QueryBase> = IQueryResult,
+> = Type<IQueryHandler<QueryBase, QueryResultBase>>;
 
 @Injectable()
 export class QueryBus<QueryBase extends IQuery = IQuery>
   extends ObservableBus<QueryBase>
-  implements IQueryBus<QueryBase> {
+  implements IQueryBus<QueryBase>
+{
   private handlers = new Map<string, IQueryHandler<QueryBase, IQueryResult>>();
   private _publisher: IQueryPublisher<QueryBase>;
 
@@ -38,7 +41,7 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
     this._publisher = _publisher;
   }
 
-  async execute<T extends QueryBase, TResult = any>(
+  async execute<T extends QueryBase, TResult = IQueryResult<T>>(
     query: T,
   ): Promise<TResult> {
     const queryId = this.getQueryId(query);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ n/a ] Tests for the changes have been added (for bug fixes / features)
- [ n/a ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ X ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When dispatching a query from the QueryBus, the return type of the execute method is IQueryResult. If the intent of a query is to return a response, it would be useful to have type inference for the expected response.

Issue Number: #167 

## What is the new behavior?
`IQueryResult` interface have an optional type parameter of corresponding query type and infers itself from `IQuery`
`TRes` parameter.
`IQueryHandler`, `IQueryBus` and `QueryBus` types were updated in order to use new this feature.

Behavior is still backward compatible, as it respects override on method, class or query methods

## Does this PR introduce a breaking change?
- [ ] Yes
- [ X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
