### PR TITLE
style(cqrs): fix typing for CommandHandler to actually accept the type of class extending ICommand

### DIFF
--- a/src/decorators/command-handler.decorator.ts
+++ b/src/decorators/command-handler.decorator.ts
@@ -13,7 +13,7 @@ import { v4 } from 'uuid';
  *
  * @see https://docs.nestjs.com/recipes/cqrs#commands
  */
-export const CommandHandler = (command: ICommand): ClassDecorator => {
+export const CommandHandler = (command: ICommand | (new (...args: any[]) => ICommand)): ClassDecorator => {
   return (target: object) => {
     if (!Reflect.hasMetadata(COMMAND_METADATA, command)) {
       Reflect.defineMetadata(COMMAND_METADATA, { id: v4() }, command);


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Typing fix

## What is the current behavior?

I extended `ICommand` interface via TypeScript's Declaration Merging, adding own properties there, so that I can enforce all my commands to adhere to some standard format. This made my code not compile due to invalid/incomplete typing for `CommandHandler` decorator, which expects `ICommand` *instance* passed as an argument, while the documented intention is that it accepts `ICommand`-compatible *type*.

Issue Number: N/A


## What is the new behavior?

I extended the existing typing so that the actual class type that implements `ICommand` is accepted by `CommandHandler` decorator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
