### PR TITLE
style(cqrs): fix typing for EventsHandler to accept the type of class extending IEvent

### DIFF
--- a/src/decorators/events-handler.decorator.ts
+++ b/src/decorators/events-handler.decorator.ts
@@ -13,7 +13,7 @@ import { v4 } from 'uuid';
  *
  * @see https://docs.nestjs.com/recipes/cqrs#events
  */
-export const EventsHandler = (...events: IEvent[]): ClassDecorator => {
+export const EventsHandler = (...events: (IEvent | (new (...args: any[]) => IEvent))[]): ClassDecorator => {
   return (target: object) => {
     events.forEach((event) => {
       if (!Reflect.hasOwnMetadata(EVENT_METADATA, event)) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
I extended IEvent interface via TypeScript's Declaration Merging, adding own properties there, so that I can enforce all my events to adhere to some standard format. This made my code not compile due to invalid/incomplete typing for EventsHandler decorator.
I believe IEvent interface should have ability to be extendible in same manner as ICommand became extendible with [this PR](https://github.com/nestjs/cqrs/pull/1206).

Issue Number: N/A


## What is the new behavior?
I extended the existing typing so that the actual class type that implements IEvent is accepted by EventsHandler decorator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
