### PR TITLE
feat: add unhandled exceptions bus

### DIFF
--- a/src/cqrs.module.ts
+++ b/src/cqrs.module.ts
@@ -5,10 +5,24 @@ import { EventPublisher } from './event-publisher';
 import { IEvent } from './interfaces';
 import { QueryBus } from './query-bus';
 import { ExplorerService } from './services/explorer.service';
+import { UnhandledExceptionBus } from './unhandled-exception-bus';
 
 @Module({
-  providers: [CommandBus, QueryBus, EventBus, EventPublisher, ExplorerService],
-  exports: [CommandBus, QueryBus, EventBus, EventPublisher],
+  providers: [
+    CommandBus,
+    QueryBus,
+    EventBus,
+    UnhandledExceptionBus,
+    EventPublisher,
+    ExplorerService,
+  ],
+  exports: [
+    CommandBus,
+    QueryBus,
+    EventBus,
+    UnhandledExceptionBus,
+    EventPublisher,
+  ],
 })
 export class CqrsModule<EventBase extends IEvent = IEvent>
   implements OnApplicationBootstrap

--- a/src/cqrs.module.ts
+++ b/src/cqrs.module.ts
@@ -11,20 +11,21 @@ import { ExplorerService } from './services/explorer.service';
   exports: [CommandBus, QueryBus, EventBus, EventPublisher],
 })
 export class CqrsModule<EventBase extends IEvent = IEvent>
-  implements OnApplicationBootstrap {
+  implements OnApplicationBootstrap
+{
   constructor(
     private readonly explorerService: ExplorerService<EventBase>,
-    private readonly eventsBus: EventBus<EventBase>,
-    private readonly commandsBus: CommandBus,
+    private readonly eventBus: EventBus<EventBase>,
+    private readonly commandBus: CommandBus,
     private readonly queryBus: QueryBus,
   ) {}
 
   onApplicationBootstrap() {
     const { events, queries, sagas, commands } = this.explorerService.explore();
 
-    this.eventsBus.register(events);
-    this.commandsBus.register(commands);
+    this.eventBus.register(events);
+    this.commandBus.register(commands);
     this.queryBus.register(queries);
-    this.eventsBus.registerSagas(sagas);
+    this.eventBus.registerSagas(sagas);
   }
 }

--- a/src/helpers/default-unhandled-exception-pubsub.ts
+++ b/src/helpers/default-unhandled-exception-pubsub.ts
@@ -1,0 +1,20 @@
+import { Subject } from 'rxjs';
+import {
+  ICommand,
+  IEvent,
+  IUnhandledExceptionPublisher,
+  UnhandledExceptionInfo,
+} from '../interfaces';
+
+/**
+ * Default implementation of the `IUnhandledExceptionPublisher` interface.
+ */
+export class DefaultUnhandledExceptionPubSub<Cause = IEvent | ICommand>
+  implements IUnhandledExceptionPublisher<Cause>
+{
+  constructor(private subject$: Subject<UnhandledExceptionInfo<Cause>>) {}
+
+  publish(info: UnhandledExceptionInfo<Cause>) {
+    this.subject$.next(info);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,4 +15,5 @@ export * from './exceptions';
 export * from './interfaces';
 export * from './operators';
 export * from './query-bus';
+export * from './unhandled-exception-bus';
 export * from './utils';

--- a/src/interfaces/exceptions/unhandled-exception-info.interface.ts
+++ b/src/interfaces/exceptions/unhandled-exception-info.interface.ts
@@ -1,0 +1,16 @@
+import { ICommand } from '../commands/command.interface';
+import { IEvent } from '../events/event.interface';
+
+export interface UnhandledExceptionInfo<
+  Cause = IEvent | ICommand,
+  Exception = any,
+> {
+  /**
+   * The exception that was thrown.
+   */
+  exception: Exception;
+  /**
+   * The cause of the exception.
+   */
+  cause: Cause;
+}

--- a/src/interfaces/exceptions/unhandled-exception-publisher.interface.ts
+++ b/src/interfaces/exceptions/unhandled-exception-publisher.interface.ts
@@ -1,0 +1,14 @@
+import { ICommand } from '../commands/command.interface';
+import { IEvent } from '../events/event.interface';
+import { UnhandledExceptionInfo } from './unhandled-exception-info.interface';
+
+export interface IUnhandledExceptionPublisher<
+  CauseBase = IEvent | ICommand,
+  ExceptionBase = any,
+> {
+  /**
+   * Publishes an unhandled exception.
+   * @param info The exception information.
+   */
+  publish(info: UnhandledExceptionInfo<CauseBase, ExceptionBase>): any;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -7,6 +7,8 @@ export * from './events/event-handler.interface';
 export * from './events/event-publisher.interface';
 export * from './events/event.interface';
 export * from './events/message-source.interface';
+export * from './exceptions/unhandled-exception-info.interface';
+export * from './exceptions/unhandled-exception-publisher.interface';
 export * from './queries/query-bus.interface';
 export * from './queries/query-handler.interface';
 export * from './queries/query-publisher.interface';

--- a/src/unhandled-exception-bus.ts
+++ b/src/unhandled-exception-bus.ts
@@ -1,0 +1,72 @@
+import { Injectable, Type } from '@nestjs/common';
+import 'reflect-metadata';
+import { Observable, filter } from 'rxjs';
+import { DefaultUnhandledExceptionPubSub } from './helpers/default-unhandled-exception-pubsub';
+import {
+  ICommand,
+  IEvent,
+  IUnhandledExceptionPublisher,
+  UnhandledExceptionInfo,
+} from './interfaces';
+import { ObservableBus } from './utils/observable-bus';
+
+/**
+ * A bus that publishes unhandled exceptions.
+ * @template Cause The type of the cause of the exception.
+ */
+@Injectable()
+export class UnhandledExceptionBus<
+  Cause = IEvent | ICommand,
+> extends ObservableBus<UnhandledExceptionInfo<Cause>> {
+  private _publisher: IUnhandledExceptionPublisher<Cause>;
+
+  constructor() {
+    super();
+    this.useDefaultPublisher();
+  }
+
+  /**
+   * Filter values depending on their instance type (comparison is made
+   * using native `instanceof`).
+   *
+   * @param types List of types to filter by.
+   * @return A stream only emitting the filtered exceptions.
+   */
+  static ofType<TInput, TOutput>(...types: Type<TOutput>[]) {
+    const isInstanceOf = (
+      exceptionInfo: UnhandledExceptionInfo,
+    ): exceptionInfo is UnhandledExceptionInfo<TOutput> =>
+      !!types.find((classType) => exceptionInfo.exception instanceof classType);
+
+    return (
+      source: Observable<UnhandledExceptionInfo<TInput>>,
+    ): Observable<UnhandledExceptionInfo<TOutput>> =>
+      source.pipe(filter(isInstanceOf));
+  }
+
+  /**
+   * Gets the publisher of the bus.
+   */
+  get publisher(): IUnhandledExceptionPublisher<Cause> {
+    return this._publisher;
+  }
+
+  /**
+   * Sets the publisher of the bus.
+   */
+  set publisher(_publisher: IUnhandledExceptionPublisher<Cause>) {
+    this._publisher = _publisher;
+  }
+
+  /**
+   * Publishes an unhandled exception.
+   * @param info The exception information.
+   */
+  publish(info: UnhandledExceptionInfo<Cause>) {
+    return this._publisher.publish(info);
+  }
+
+  private useDefaultPublisher() {
+    this._publisher = new DefaultUnhandledExceptionPubSub<Cause>(this.subject$);
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Provides the `UnhandledExceptionBus` injectable that lets you react to unhandled exceptions that were thrown from either event handlers or sagas:

```typescript
private readonly destroy$ = new Subject<void>();

constructor(private readonly unhandledExceptionsBus: UnhandledExceptionBus) {
  this.unhandledExceptionsBus
    .pipe(takeUntil(this.destroy$))
    .subscribe((exceptionInfo) => {
      // Handle exception here
      // e.g. send it to external service, terminate process, or publish a new event
    });
}

onModuleDestroy() {
  this.destroy$.next();
  this.destroy$.complete();
}
```

To filter out stream and subscribe to a specific exception type, use the `UnhandledExceptionBus.ofType` operator, as follows:

```typescript
this.unhandledExceptionsBus
  .pipe(
    takeUntil(this.destroy$),
    UnhandledExceptionBus.ofType(TransactionNotAllowedException),
  )
  .subscribe((exceptionInfo) => {});
```

Payload interface:

```typescript
/**
 * Represents an unhandled exception.
 */
export interface UnhandledExceptionInfo<
  Cause = IEvent | ICommand,
  Exception = any,
> {
  /**
   * The exception that was thrown.
   */
  exception: Exception;
  /**
   * The cause of the exception (event or command reference).
   */
  cause: Cause;
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
