### PR TITLE
Add publishable decorator to automatically merge publisher into decorated AggregateRoot

### DIFF
--- a/src/cqrs.module.ts
+++ b/src/cqrs.module.ts
@@ -6,6 +6,7 @@ import { IEvent } from './interfaces';
 import { QueryBus } from './query-bus';
 import { ExplorerService } from './services/explorer.service';
 import { UnhandledExceptionBus } from './unhandled-exception-bus';
+import { AggregateRootStorage } from './storages/aggregate-root.storage';
 
 @Module({
   providers: [
@@ -52,5 +53,7 @@ export class CqrsModule<EventBase extends IEvent = IEvent>
     this.commandBus.register(commands);
     this.queryBus.register(queries);
     this.eventBus.registerSagas(sagas);
+
+    AggregateRootStorage.mergeContext(this.eventBus);
   }
 }

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -2,3 +2,4 @@ export * from './command-handler.decorator';
 export * from './events-handler.decorator';
 export * from './query-handler.decorator';
 export * from './saga.decorator';
+export * from './publishable.decorator';

--- a/src/decorators/publishable.decorator.ts
+++ b/src/decorators/publishable.decorator.ts
@@ -1,0 +1,11 @@
+import { AggregateRootStorage } from '../storages/aggregate-root.storage';
+
+/**
+ * Merges event publisher with the decorated class.
+ * Implements the `publish` and `publishAll` methods in a similar way to {@link EventPublisher#mergeClassContext}.
+ */
+export function Publishable(): ClassDecorator {
+  return (target: any) => {
+    AggregateRootStorage.add(target);
+  };
+}

--- a/src/storages/aggregate-root.storage.ts
+++ b/src/storages/aggregate-root.storage.ts
@@ -1,0 +1,24 @@
+import { Type } from '@nestjs/common';
+import { EventBus } from '../event-bus';
+import { IEvent } from '../interfaces';
+import { AggregateRoot } from '../aggregate-root';
+
+export class AggregateRootStorage {
+  private static storage: Array<Type<AggregateRoot>> = [];
+
+  static add(type: Type<AggregateRoot>): void {
+    this.storage.push(type);
+  }
+
+  static mergeContext(eventBus: EventBus): void {
+    for (const item of this.storage) {
+      item.prototype.publish = function (event: IEvent) {
+        eventBus.publish(event);
+      };
+
+      item.prototype.publishAll = function (events: IEvent[]) {
+        eventBus.publishAll(events);
+      };
+    }
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

Issue Number: #1466

## What is the new behavior?
Added the `@Publishable()` decorator that holds the decorated class to the internal storage to merge them with the event publisher on the application bootstrap.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
