### PR TITLE
test: fix type error in of-type.spec.ts

### DIFF
--- a/src/operators/of-type.spec.ts
+++ b/src/operators/of-type.spec.ts
@@ -32,7 +32,7 @@ describe('operators/ofType', () => {
     expectedResults.push(new A());
 
     stream.next(new B());
-    stream.next(...expectedResults);
+    expectedResults.forEach((event) => stream.next(event));
     stream.next(new Date());
 
     expect(output).toEqual(expectedResults);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: type error in test

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
```
> @nestjs/cqrs@10.2.6 test
> jest

 FAIL  src/operators/of-type.spec.ts
  ● Test suite failed to run
                                                                                                                                                                                                             
    src/operators/of-type.spec.ts:35:17 - error TS2556: A spread argument must either have a tuple type or be passed to a rest parameter.

    35     stream.next(...expectedResults);
                       ~~~~~~~~~~~~~~~~~~

Test Suites: 1 failed, 1 total                                                                                                                                                                               
Tests:       0 total                                                                                                                                                                                         
Snapshots:   0 total
Time:        1.561 s
Ran all test suites.
```
Issue Number: N/A


## What is the new behavior?
Tests passes. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
