### PR TITLE
feat: typed response command

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -14,6 +14,7 @@ import {
   ICommandBus,
   ICommandHandler,
   ICommandPublisher,
+  HookedResponse,
 } from './interfaces/index';
 import { ObservableBus } from './utils/observable-bus';
 
@@ -54,7 +55,7 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
    * @param command The command to execute.
    * @returns A promise that, when resolved, will contain the result returned by the command's handler.
    */
-  execute<T extends CommandBase, R = any>(command: T): Promise<R> {
+  execute<T extends CommandBase, R = HookedResponse<T>>(command: T): Promise<R> {
     const commandId = this.getCommandId(command);
     const handler = this.handlers.get(commandId);
     if (!handler) {

--- a/src/interfaces/commands/command.interface.ts
+++ b/src/interfaces/commands/command.interface.ts
@@ -1,1 +1,3 @@
-export interface ICommand {}
+import { IHookedResponse } from '../hooked-response.interface';
+
+export interface ICommand<TResponse = any> extends IHookedResponse<TResponse> {}

--- a/src/interfaces/hooked-response.interface.ts
+++ b/src/interfaces/hooked-response.interface.ts
@@ -1,0 +1,10 @@
+const responseType = Symbol('responseType');
+
+export type IHookedResponse<out TResponse = any> = {
+    [responseType]?: TResponse
+}
+
+export type HookedResponse<T extends IHookedResponse> =
+    unknown extends Required<T>[typeof responseType]
+    ? any
+    : Required<T>[typeof responseType];

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -9,6 +9,7 @@ export * from './events/event.interface';
 export * from './events/message-source.interface';
 export * from './exceptions/unhandled-exception-info.interface';
 export * from './exceptions/unhandled-exception-publisher.interface';
+export * from './hooked-response.interface';
 export * from './queries/query-bus.interface';
 export * from './queries/query-handler.interface';
 export * from './queries/query-publisher.interface';

--- a/src/interfaces/queries/query.interface.ts
+++ b/src/interfaces/queries/query.interface.ts
@@ -1,1 +1,3 @@
-export interface IQuery {}
+import { IHookedResponse } from '../hooked-response.interface';
+
+export interface IQuery<T = any> extends IHookedResponse<T> {}

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -6,6 +6,7 @@ import { QueryHandlerNotFoundException } from './exceptions';
 import { InvalidQueryHandlerException } from './exceptions/invalid-query-handler.exception';
 import { DefaultQueryPubSub } from './helpers/default-query-pubsub';
 import {
+  HookedResponse,
   IQuery,
   IQueryBus,
   IQueryHandler,
@@ -53,7 +54,7 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
    * Executes a query.
    * @param query The query to execute.
    */
-  async execute<T extends QueryBase, TResult = any>(
+  async execute<T extends QueryBase, TResult = HookedResponse<T>>(
     query: T,
   ): Promise<TResult> {
     const queryId = this.getQueryId(query);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The execute methods of CommandBus and QueryBus return any by default or the return type informed as generics, there's no way to intrinsically associate a return type to a command.

Issue Number: N/A


## What is the new behavior?

If the command/query class attends two requisites the return type will be inferred:
* It extends of `ICommand<ReturnType>`/`IQuery<ReturnType>`;
* It is merged with an interface declaration of the  same name that inherits `ICommand<ReturnType>`/`IQuery<ReturnType>`

Example:
```ts
class MyCommand implements ICommand<string> {}
interface MyCommand extends ICommand<string> {}
```

If the command doesn't attend both requisites, commandBus, and queryBus will still return any, making of this change a safe one, as no previous behavior got broken.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I'll update whatever documentation I need if the idea is accepted.

Although it's not ideal to merge a class and interface declaration, in some specific scenarios, like this one, this may bring some benefits and more type-safe code. I hope someday Typescript evolves so that this can work without the merge trick.
