### PR TITLE
chore(deps): Use `crypto.randomUUID()` instead of `uuid` module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@nestjs/cqrs",
       "version": "10.2.8",
       "license": "MIT",
-      "dependencies": {
-        "uuid": "11.0.2"
-      },
       "devDependencies": {
         "@commitlint/cli": "19.6.1",
         "@commitlint/config-angular": "19.6.0",
@@ -11941,19 +11938,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.2.tgz",
-      "integrity": "sha512-14FfcOJmqdjbBPdDjFQyk/SdT4NySW4eM0zcG+HqbHP5jzuH56xO3J1DGhgs/cEMCfwYi3HQI1gnTO62iaG+tQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,16 +17,13 @@
     "release": "release-it",
     "prepare": "husky install"
   },
-  "dependencies": {
-    "uuid": "11.0.2"
-  },
   "devDependencies": {
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-angular": "19.6.0",
     "@nestjs/common": "10.4.15",
     "@nestjs/core": "10.4.15",
-    "@types/node": "22.10.5",
     "@types/jest": "29.5.14",
+    "@types/node": "22.10.5",
     "@typescript-eslint/eslint-plugin": "8.19.0",
     "@typescript-eslint/parser": "8.19.0",
     "eslint": "9.17.0",

--- a/src/decorators/command-handler.decorator.ts
+++ b/src/decorators/command-handler.decorator.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { ICommand } from '../index';
 import { COMMAND_HANDLER_METADATA, COMMAND_METADATA } from './constants';
-import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest command handler. A command handler
@@ -18,7 +17,7 @@ export const CommandHandler = (
 ): ClassDecorator => {
   return (target: object) => {
     if (!Reflect.hasOwnMetadata(COMMAND_METADATA, command)) {
-      Reflect.defineMetadata(COMMAND_METADATA, { id: v4() }, command);
+      Reflect.defineMetadata(COMMAND_METADATA, { id: crypto.randomUUID() }, command);
     }
     Reflect.defineMetadata(COMMAND_HANDLER_METADATA, command, target);
   };

--- a/src/decorators/events-handler.decorator.ts
+++ b/src/decorators/events-handler.decorator.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { IEvent } from '../index';
 import { EVENT_METADATA, EVENTS_HANDLER_METADATA } from './constants';
-import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest event handler. An event handler
@@ -19,7 +18,7 @@ export const EventsHandler = (
   return (target: object) => {
     events.forEach((event) => {
       if (!Reflect.hasOwnMetadata(EVENT_METADATA, event)) {
-        Reflect.defineMetadata(EVENT_METADATA, { id: v4() }, event);
+        Reflect.defineMetadata(EVENT_METADATA, { id: crypto.randomUUID() }, event);
       }
     });
 

--- a/src/decorators/query-handler.decorator.ts
+++ b/src/decorators/query-handler.decorator.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { IQuery } from '../interfaces';
 import { QUERY_HANDLER_METADATA, QUERY_METADATA } from './constants';
-import { v4 } from 'uuid';
 
 /**
  * Decorator that marks a class as a Nest query handler. A query handler
@@ -16,7 +15,7 @@ import { v4 } from 'uuid';
 export const QueryHandler = (query: IQuery): ClassDecorator => {
   return (target: object) => {
     if (!Reflect.hasOwnMetadata(QUERY_METADATA, query)) {
-      Reflect.defineMetadata(QUERY_METADATA, { id: v4() }, query);
+      Reflect.defineMetadata(QUERY_METADATA, { id: crypto.randomUUID() }, query);
     }
     Reflect.defineMetadata(QUERY_HANDLER_METADATA, query, target);
   };


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No if Node.js ^18 is required (which is the oldest supported version)

The `crypto` global is available in all supported Node.js versions as well as [in all major browsers](https://caniuse.com/mdn-api_crypto_randomuuid). The uuid module is rendered unnecessary for uuidv4.

`@nestjs/graphql` is currently downloaded about 580000 times per week, so about 30740000 times per year. `uuid@11` is about 3.7 kB in size (gzipped+minified). Removing this dependency saves about 113GB traffic per year.