### PR TITLE
fix(eventbus): Use a constructor reference from handler.instance

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -297,7 +297,12 @@ export class EventBus<EventBase extends IEvent = IEvent>
   protected registerHandler(
     handler: InstanceWrapper<IEventHandler<EventBase>>,
   ) {
-    const typeRef = handler.metatype as Type<IEventHandler<EventBase>>;
+    const typeRef = (
+      handler.metatype || handler.inject
+        ? handler.instance?.constructor
+        : handler.metatype
+    ) as Type<IEventHandler<EventBase>>;
+
     const events = this.reflectEvents(typeRef);
     events.forEach((event) => {
       const eventId = this.eventIdProvider.getEventId(event);


### PR DESCRIPTION
if undefined, fallback to handler.metadata

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix

## What is the current behavior?
Cannot register an EventHandler on EventBus With NestJs 11.x

[Issue Number: N/A](https://github.com/nestjs/cqrs/issues/1908)

## What is the new behavior?
Instead of using handler.metadata, we should retrieve a constructor reference from handler.instance and use it instead. Only if it's undefined, then we should fallback to handler.metadata

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No