### PR TITLE
feat: store event operators in EventBus allowing publish sync 

### DIFF
--- a/src/event-bus.ts
+++ b/src/event-bus.ts
@@ -8,8 +8,8 @@ import {
 } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
-import { Observable, Subscription, defer, of } from 'rxjs';
-import { catchError, filter, mergeMap } from 'rxjs/operators';
+import { Observable, Subscription, UnaryFunction, defer, of, pipe } from 'rxjs';
+import { catchError, filter, mergeMap, tap } from 'rxjs/operators';
 import { CommandBus } from './command-bus';
 import { CQRS_MODULE_OPTIONS } from './constants';
 import { EVENTS_HANDLER_METADATA, SAGA_METADATA } from './decorators/constants';
@@ -38,6 +38,11 @@ export type EventHandlerType<EventBase extends IEvent = IEvent> = Type<
   IEventHandler<EventBase>
 >;
 
+export type EventOperator<EventBase extends IEvent = IEvent> = UnaryFunction<
+  Observable<EventBase>,
+  Observable<any>
+>;
+
 /**
  * @publicApi
  */
@@ -48,6 +53,8 @@ export class EventBus<EventBase extends IEvent = IEvent>
 {
   protected eventIdProvider: EventIdProvider<EventBase>;
   protected readonly subscriptions: Subscription[];
+
+  public readonly eventOperators: EventOperator<EventBase>[] = [];
 
   private _publisher: IEventPublisher<EventBase>;
   private readonly _logger = new Logger(EventBus.name);
@@ -226,8 +233,6 @@ export class EventBus<EventBase extends IEvent = IEvent>
   }
 
   bind(handler: InstanceWrapper<IEventHandler<EventBase>>, id: string) {
-    const stream$ = id ? this.ofEventId(id) : this.subject$;
-
     const deferred = handler.isDependencyTreeStatic()
       ? (event: EventBase) => () => {
           return Promise.resolve(handler.instance.handle(event));
@@ -244,26 +249,28 @@ export class EventBus<EventBase extends IEvent = IEvent>
           return instance.handle(event);
         };
 
-    const subscription = stream$
-      .pipe(
-        mergeMap((event) =>
-          defer(deferred(event)).pipe(
-            catchError((error) => {
-              if (this.options?.rethrowUnhandled) {
-                throw error;
-              }
-              const unhandledError = this.mapToUnhandledErrorInfo(event, error);
-              this.unhandledExceptionBus.publish(unhandledError);
-              this._logger.error(
-                `"${handler.constructor.name}" has thrown an unhandled exception.`,
-                error,
-              );
-              return of();
-            }),
-          ),
+    const eventOperator = pipe(
+      this.filterEventWithId(id),
+      mergeMap((event) =>
+        defer(deferred(event)).pipe(
+          catchError((error) => {
+            if (this.options?.rethrowUnhandled) {
+              throw error;
+            }
+            const unhandledError = this.mapToUnhandledErrorInfo(event, error);
+            this.unhandledExceptionBus.publish(unhandledError);
+            this._logger.error(
+              `"${handler.constructor.name}" has thrown an unhandled exception.`,
+              error,
+            );
+            return of();
+          }),
         ),
-      )
-      .subscribe();
+      ),
+    );
+
+    this.eventOperators.push(eventOperator);
+    const subscription = this.subject$.pipe(eventOperator).subscribe();
     this.subscriptions.push(subscription);
   }
 
@@ -313,16 +320,17 @@ export class EventBus<EventBase extends IEvent = IEvent>
     });
   }
 
-  protected ofEventId(id: string) {
-    return this.subject$.pipe(
-      filter((event) => {
-        const { constructor } = Object.getPrototypeOf(event);
-        if (!constructor) {
-          return false;
-        }
-        return this.eventIdProvider.getEventId(constructor) === id;
-      }),
-    );
+  protected filterEventWithId(id: string | null) {
+    if (!id) {
+      return tap<EventBase>();
+    }
+    return filter<EventBase>((event) => {
+      const { constructor } = Object.getPrototypeOf(event);
+      if (!constructor) {
+        return false;
+      }
+      return this.eventIdProvider.getEventId(constructor) === id;
+    });
   }
 
   protected registerSaga(saga: ISaga<EventBase>) {

--- a/test/e2e/sync-event-handlers-app.spec.ts
+++ b/test/e2e/sync-event-handlers-app.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MockInstance, vi } from 'vitest';
+import { AsyncHandlersAppModule } from '../src/sync-event-handlers/async-handlers-app.module';
+import { EventBus } from '../../src/event-bus';
+import { HeroKilledDragon2SlowHandler } from '../src/sync-event-handlers/events/handlers/hero-killed-dragon2-slow.handler';
+import { HeroKilledDragonSlowHandler } from '../src/sync-event-handlers/events/handlers/hero-killed-dragon-slow.handler';
+import { HeroFoundItemSlowHandler } from '../src/sync-event-handlers/events/handlers/hero-found-item-slow.handler';
+import { SyncHandlersAppModule } from '../src/sync-event-handlers/sync-handlers-app.module';
+import { HeroFoundItemEvent } from '../src/heroes/events/impl/hero-found-item.event';
+import { HeroKilledDragonEvent } from '../src/heroes/events/impl/hero-killed-dragon.event';
+
+describe('Sync event handlers', () => {
+  let moduleRef: TestingModule;
+  let eventBus: EventBus;
+  let heroFoundItemHandler: HeroFoundItemSlowHandler;
+  let heroFoundItemEnded: MockInstance;
+  let heroKilledDragonHandler: HeroKilledDragonSlowHandler;
+  let heroKilledDragonEnded: MockInstance;
+  let heroKilledDragon2Handler: HeroKilledDragon2SlowHandler;
+  let heroKilledDragon2Ended: MockInstance;
+
+  beforeEach(() => {
+    heroFoundItemEnded.mockClear();
+    heroKilledDragonEnded.mockClear();
+    heroKilledDragon2Ended.mockClear();
+  });
+
+  describe('when event handlers are fully asynchronous', () => {
+    beforeAll(async () => {
+      moduleRef = await Test.createTestingModule({
+        imports: [AsyncHandlersAppModule],
+      }).compile();
+
+      await moduleRef.init();
+      eventBus = moduleRef.get(EventBus);
+      heroFoundItemHandler = moduleRef.get(HeroFoundItemSlowHandler);
+      heroKilledDragonHandler = moduleRef.get(HeroKilledDragonSlowHandler);
+      heroKilledDragon2Handler = moduleRef.get(HeroKilledDragon2SlowHandler);
+      heroFoundItemEnded = vi.spyOn(heroFoundItemHandler, 'end');
+      heroKilledDragonEnded = vi.spyOn(heroKilledDragonHandler, 'end');
+      heroKilledDragon2Ended = vi.spyOn(heroKilledDragon2Handler, 'end');
+    });
+
+    describe('when "HeroFoundItemEvent" event is published', () => {
+      it('should wait for the event handlers to complete', async () => {
+        const event = new HeroFoundItemEvent('hero1', 'item1');
+
+        await eventBus.publish(event);
+
+        expect(heroFoundItemEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragonEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragon2Ended).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when "HeroKilledDragonEvent" event is published', () => {
+      it('should wait for the event handlers to complete', async () => {
+        const event = new HeroKilledDragonEvent('hero1', 'dragon1');
+
+        await eventBus.publish(event);
+
+        expect(heroFoundItemEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragonEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragon2Ended).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('when event handlers are synchronous', () => {
+    beforeAll(async () => {
+      moduleRef = await Test.createTestingModule({
+        imports: [SyncHandlersAppModule],
+      }).compile();
+
+      await moduleRef.init();
+      eventBus = moduleRef.get(EventBus);
+      heroFoundItemHandler = moduleRef.get(HeroFoundItemSlowHandler);
+      heroKilledDragonHandler = moduleRef.get(HeroKilledDragonSlowHandler);
+      heroKilledDragon2Handler = moduleRef.get(HeroKilledDragon2SlowHandler);
+      heroFoundItemEnded = vi.spyOn(heroFoundItemHandler, 'end');
+      heroKilledDragonEnded = vi.spyOn(heroKilledDragonHandler, 'end');
+      heroKilledDragon2Ended = vi.spyOn(heroKilledDragon2Handler, 'end');
+    });
+
+    describe('when "HeroFoundItemEvent" event is published', () => {
+      it('should wait for the event handlers to complete', async () => {
+        const event = new HeroFoundItemEvent('hero1', 'item1');
+
+        await eventBus.publish(event);
+
+        expect(heroFoundItemEnded).toHaveBeenCalledTimes(1);
+        expect(heroKilledDragonEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragon2Ended).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when "HeroKilledDragonEvent" event is published', () => {
+      it('should wait for the event handlers to complete', async () => {
+        const event = new HeroKilledDragonEvent('hero1', 'dragon1');
+
+        await eventBus.publish(event);
+
+        expect(heroFoundItemEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragonEnded).toHaveBeenCalledTimes(1);
+        expect(heroKilledDragon2Ended).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('when an unknown event is published', () => {
+      it('should return directly', async () => {
+        await eventBus.publish({ id: 'unknown event' });
+
+        expect(heroFoundItemEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragonEnded).not.toHaveBeenCalled();
+        expect(heroKilledDragon2Ended).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await moduleRef.close();
+  });
+});

--- a/test/src/sync-event-handlers/async-handlers-app.module.ts
+++ b/test/src/sync-event-handlers/async-handlers-app.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '../../../src';
+import { EventHandlers } from './events/handlers';
+
+@Module({
+  imports: [CqrsModule.forRoot()],
+  providers: [...EventHandlers],
+})
+export class AsyncHandlersAppModule {}

--- a/test/src/sync-event-handlers/events/handlers/hero-found-item-slow.handler.ts
+++ b/test/src/sync-event-handlers/events/handlers/hero-found-item-slow.handler.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '../../../../../src';
+import { waitImmediate } from '../../../../utils/wait-immediate';
+import { HeroFoundItemEvent } from '../../../heroes/events/impl/hero-found-item.event';
+
+@EventsHandler(HeroFoundItemEvent)
+export class HeroFoundItemSlowHandler
+  implements IEventHandler<HeroFoundItemEvent>
+{
+  async handle(event: HeroFoundItemEvent) {
+    await waitImmediate();
+    Logger.log('HeroFoundItemEvent...', event);
+    this.end();
+  }
+
+  end() {}
+}

--- a/test/src/sync-event-handlers/events/handlers/hero-killed-dragon-slow.handler.ts
+++ b/test/src/sync-event-handlers/events/handlers/hero-killed-dragon-slow.handler.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '../../../../../src';
+import { waitImmediate } from '../../../../utils/wait-immediate';
+import { HeroKilledDragonEvent } from '../../../heroes/events/impl/hero-killed-dragon.event';
+
+@EventsHandler(HeroKilledDragonEvent)
+export class HeroKilledDragonSlowHandler
+  implements IEventHandler<HeroKilledDragonEvent>
+{
+  async handle(event: HeroKilledDragonEvent) {
+    await waitImmediate();
+    Logger.log('HeroKilledDragonEvent...', event);
+    this.end();
+  }
+
+  end() {}
+}

--- a/test/src/sync-event-handlers/events/handlers/hero-killed-dragon2-slow.handler.ts
+++ b/test/src/sync-event-handlers/events/handlers/hero-killed-dragon2-slow.handler.ts
@@ -1,0 +1,17 @@
+import { Logger } from '@nestjs/common';
+import { EventsHandler, IEventHandler } from '../../../../../src';
+import { waitImmediate } from '../../../../utils/wait-immediate';
+import { HeroKilledDragonEvent } from '../../../heroes/events/impl/hero-killed-dragon.event';
+
+@EventsHandler(HeroKilledDragonEvent)
+export class HeroKilledDragon2SlowHandler
+  implements IEventHandler<HeroKilledDragonEvent>
+{
+  async handle(event: HeroKilledDragonEvent) {
+    await waitImmediate();
+    Logger.log('HeroKilledDragonEvent 2...', event);
+    this.end();
+  }
+
+  end() {}
+}

--- a/test/src/sync-event-handlers/events/handlers/index.ts
+++ b/test/src/sync-event-handlers/events/handlers/index.ts
@@ -1,0 +1,9 @@
+import { HeroKilledDragonSlowHandler } from './hero-killed-dragon-slow.handler';
+import { HeroFoundItemSlowHandler } from './hero-found-item-slow.handler';
+import { HeroKilledDragon2SlowHandler } from './hero-killed-dragon2-slow.handler';
+
+export const EventHandlers = [
+  HeroKilledDragonSlowHandler,
+  HeroKilledDragon2SlowHandler,
+  HeroFoundItemSlowHandler,
+];

--- a/test/src/sync-event-handlers/sync-handlers-app.module.ts
+++ b/test/src/sync-event-handlers/sync-handlers-app.module.ts
@@ -1,0 +1,22 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+import { CqrsModule, EventBus, IEvent } from '../../../src';
+import { EventHandlers } from './events/handlers';
+import { SyncPublisher } from './sync-publisher';
+
+@Module({
+  imports: [
+    CqrsModule.forRoot({
+      eventPublisher: new SyncPublisher(),
+    }),
+  ],
+  providers: [...EventHandlers],
+})
+export class SyncHandlersAppModule implements OnModuleInit {
+  constructor(private readonly eventBus: EventBus) {}
+
+  onModuleInit() {
+    (this.eventBus.publisher as SyncPublisher<IEvent>).setEventOperators(
+      this.eventBus.eventOperators,
+    );
+  }
+}

--- a/test/src/sync-event-handlers/sync-publisher.ts
+++ b/test/src/sync-event-handlers/sync-publisher.ts
@@ -1,0 +1,24 @@
+import { lastValueFrom, map, merge, of } from 'rxjs';
+import { IEvent, IEventPublisher } from '../../../src/interfaces';
+import { EventOperator } from '../../../src/event-bus';
+
+export class SyncPublisher<EventBase extends IEvent>
+  implements IEventPublisher<EventBase>
+{
+  private eventOperators: EventOperator<EventBase>[] = [];
+
+  async publish<T extends EventBase>(event: T) {
+    const event$ = of(event);
+
+    await lastValueFrom(
+      merge(
+        event$.pipe(map(() => undefined)),
+        ...this.eventOperators.map((operator) => event$.pipe(operator)),
+      ),
+    );
+  }
+
+  setEventOperators<T extends EventBase>(eventOperators: EventOperator<T>[]) {
+    this.eventOperators = eventOperators;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) => I will work on that after


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [Discord discussion](https://discord.com/channels/520622812742811698/1337964416469041182/1337964416469041182)


## What is the new behavior?

The `EventBus` now exposes a new property named `eventOperators` which is an array of event handlers functions in order to be used / subscribed somewhere else than from the `EventBus`.
This an easy way I found, without introducing breaking changes, to open the event bus to be able to call event handlers synchronously.
Ex:
```ts
export class SyncPublisher<EventBase extends IEvent> implements IEventPublisher<EventBase> {
  private eventOperators: EventOperator<EventBase>[] = [];

  async publish<T extends EventBase>(event: T) {
    const event$ = of(event);

    await lastValueFrom(
      merge(
        event$.pipe(map(() => undefined)),
        ...this.eventOperators.map((operator) => event$.pipe(operator)),
      ),
    );
  }

  setEventOperators<T extends EventBase>(eventOperators: EventOperator<T>[]) {
    this.eventOperators = eventOperators;
  }
}

@Module({
  imports: [
    CqrsModule.forRoot({
      eventPublisher: new SyncPublisher(),
    }),
  ],
  // [...]
})
export class AppModule implements OnModuleInit {
  constructor(private readonly eventBus: EventBus) {}

  onModuleInit() {
    (this.eventBus.publisher as SyncPublisher<IEvent>).setEventOperators(
      this.eventBus.eventOperators,
    );
  }
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information