### PR TITLE
feat: add support for using factory providers for `QueryHandler` and `CommandHandler`

### DIFF
--- a/src/command-bus.ts
+++ b/src/command-bus.ts
@@ -160,7 +160,9 @@ export class CommandBus<CommandBase extends ICommand = ICommand>
   protected registerHandler(
     handler: InstanceWrapper<ICommandHandler<CommandBase>>,
   ) {
-    const typeRef = handler.metatype as Type<ICommandHandler<CommandBase>>;
+    const typeRef = (
+      handler.inject ? handler.instance?.constructor : handler.metatype
+    ) as Type<ICommandHandler<CommandBase>>;
     const target = this.reflectCommandId(typeRef);
     if (!target) {
       throw new InvalidCommandHandlerException();

--- a/src/query-bus.ts
+++ b/src/query-bus.ts
@@ -153,7 +153,9 @@ export class QueryBus<QueryBase extends IQuery = IQuery>
   protected registerHandler(
     handler: InstanceWrapper<IQueryHandler<QueryBase>>,
   ) {
-    const typeRef = handler.metatype as Type<IQueryHandler<QueryBase>>;
+    const typeRef = (
+      handler.inject ? handler.instance?.constructor : handler.metatype
+    ) as Type<IQueryHandler<QueryBase>>;
     const target = this.reflectQueryId(typeRef);
     if (!target) {
       throw new InvalidQueryHandlerException();

--- a/src/services/explorer.service.ts
+++ b/src/services/explorer.service.ts
@@ -48,14 +48,11 @@ export class ExplorerService<EventBase extends IEvent = IEvent> {
   }
 
   filterByMetadataKey(wrapper: InstanceWrapper, metadataKey: string) {
-    const { instance } = wrapper;
-    if (!instance) {
+    const clsRef = wrapper.instance?.constructor ?? wrapper.metatype;
+    if (!clsRef) {
       return;
     }
-    if (!instance.constructor) {
-      return;
-    }
-    const metadata = Reflect.getMetadata(metadataKey, instance.constructor);
+    const metadata = Reflect.getMetadata(metadataKey, clsRef);
     if (!metadata) {
       return;
     }

--- a/test/e2e/basic-flows.spec.ts
+++ b/test/e2e/basic-flows.spec.ts
@@ -10,7 +10,7 @@ import { HeroFoundItemHandler } from '../src/heroes/events/handlers/hero-found-i
 import { HeroKilledDragonHandler } from '../src/heroes/events/handlers/hero-killed-dragon.handler';
 import { HeroFoundItemEvent } from '../src/heroes/events/impl/hero-found-item.event';
 import { HeroKilledDragonEvent } from '../src/heroes/events/impl/hero-killed-dragon.event';
-import { GetHeroesQuery } from '../src/heroes/queries/impl';
+import { GetHeroesQuery, GetHeroQuery } from '../src/heroes/queries/impl';
 import { HERO_ID } from '../src/heroes/repository/fixtures/user';
 import { ANCIENT_ITEM_ID } from '../src/heroes/sagas/heroes.sagas';
 import { NoopHandler } from '../src/noop/events/handlers/noop.handler';
@@ -97,6 +97,14 @@ describe('Basic flows', () => {
       const queryBus = moduleRef.get(QueryBus);
       const heroes = await queryBus.execute(new GetHeroesQuery());
       expect(heroes).toEqual([expect.objectContaining({ id: HERO_ID })]);
+    });
+  });
+
+  describe('when "GetHeroQuery" query is executed', () => {
+    it('should return a single hero', async () => {
+      const queryBus = moduleRef.get(QueryBus);
+      const hero = await queryBus.execute(new GetHeroQuery(1234));
+      expect(hero).toEqual(expect.objectContaining({ id: HERO_ID }));
     });
   });
 

--- a/test/src/heroes/commands/handlers/index.ts
+++ b/test/src/heroes/commands/handlers/index.ts
@@ -1,4 +1,15 @@
-import { KillDragonHandler } from './kill-dragon.handler';
+import { Provider } from '@nestjs/common';
+import { EventPublisher, ICommandHandler } from '../../../../../src';
+import { HeroRepository } from '../../repository/hero.repository';
 import { DropAncientItemHandler } from './drop-ancient-item.handler';
+import { KillDragonHandler } from './kill-dragon.handler';
 
-export const CommandHandlers = [KillDragonHandler, DropAncientItemHandler];
+export const CommandHandlers: Provider<ICommandHandler>[] = [
+  KillDragonHandler,
+  {
+    provide: DropAncientItemHandler,
+    inject: [HeroRepository, EventPublisher],
+    useFactory: (repository, publisher) =>
+      new DropAncientItemHandler(repository, publisher),
+  },
+];

--- a/test/src/heroes/commands/handlers/index.ts
+++ b/test/src/heroes/commands/handlers/index.ts
@@ -1,10 +1,9 @@
-import { Provider } from '@nestjs/common';
-import { EventPublisher, ICommandHandler } from '../../../../../src';
+import { EventPublisher } from '../../../../../src';
 import { HeroRepository } from '../../repository/hero.repository';
 import { DropAncientItemHandler } from './drop-ancient-item.handler';
 import { KillDragonHandler } from './kill-dragon.handler';
 
-export const CommandHandlers: Provider<ICommandHandler>[] = [
+export const CommandHandlers = [
   KillDragonHandler,
   {
     provide: DropAncientItemHandler,

--- a/test/src/heroes/queries/handlers/get-hero.handler.ts
+++ b/test/src/heroes/queries/handlers/get-hero.handler.ts
@@ -1,0 +1,14 @@
+import { Logger } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '../../../../../src';
+import { HeroRepository } from '../../repository/hero.repository';
+import { GetHeroQuery } from '../impl';
+
+@QueryHandler(GetHeroQuery)
+export class GetHeroHandler implements IQueryHandler<GetHeroQuery> {
+  constructor(private readonly repository: HeroRepository) {}
+
+  async execute(query: GetHeroQuery) {
+    Logger.debug('GetHeroQuery has been called');
+    return this.repository.findOneById(query.id);
+  }
+}

--- a/test/src/heroes/queries/handlers/index.ts
+++ b/test/src/heroes/queries/handlers/index.ts
@@ -1,3 +1,14 @@
+import { Provider } from '@nestjs/common';
+import { IQueryHandler } from '../../../../../src';
+import { HeroRepository } from '../../repository/hero.repository';
+import { GetHeroHandler } from './get-hero.handler';
 import { GetHeroesHandler } from './get-heroes.handler';
 
-export const QueryHandlers = [GetHeroesHandler];
+export const QueryHandlers: Provider<IQueryHandler>[] = [
+  GetHeroesHandler,
+  {
+    provide: GetHeroHandler,
+    inject: [HeroRepository],
+    useFactory: (repository) => new GetHeroHandler(repository),
+  },
+];

--- a/test/src/heroes/queries/handlers/index.ts
+++ b/test/src/heroes/queries/handlers/index.ts
@@ -1,10 +1,8 @@
-import { Provider } from '@nestjs/common';
-import { IQueryHandler } from '../../../../../src';
 import { HeroRepository } from '../../repository/hero.repository';
 import { GetHeroHandler } from './get-hero.handler';
 import { GetHeroesHandler } from './get-heroes.handler';
 
-export const QueryHandlers: Provider<IQueryHandler>[] = [
+export const QueryHandlers = [
   GetHeroesHandler,
   {
     provide: GetHeroHandler,

--- a/test/src/heroes/queries/impl/get-hero.query.ts
+++ b/test/src/heroes/queries/impl/get-hero.query.ts
@@ -1,0 +1,3 @@
+export class GetHeroQuery {
+  constructor(public readonly id: number) {}
+}

--- a/test/src/heroes/queries/impl/index.ts
+++ b/test/src/heroes/queries/impl/index.ts
@@ -1,1 +1,2 @@
+export * from './get-hero.query';
 export * from './get-heroes.query';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, all `@QueryHandler` and `@CommandHandler` implementations need to be class providers.
If a factory provider is used, a `TypeError` is thrown when trying to reflect the command \ query metadata, eg:

```
TypeError
    at Reflect.getMetadata (/Users/work/code/apps/node_modules/reflect-metadata/Reflect.js:367:23)
    at QueryBus.reflectQueryId (/Users/work/code/apps/node_modules/@nestjs/cqrs/dist/query-bus.js:114:39)
```

## What is the new behavior?

This PR modifies the `InstanceWrapper` reflection code within `CommandBus` and `QueryBus` to support factory providers.

The implementation reflects that used in `EventBus`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
